### PR TITLE
fix: typo "exemple" fixed

### DIFF
--- a/src/docs/content/get-started.md
+++ b/src/docs/content/get-started.md
@@ -46,7 +46,7 @@ All you have to do is to add a container with the `divider` class and with the t
 #### Horizontal (default)
 {{< preview id="default" lang="html" >}}
 <div>
-    <div class="divider">Exemple</div>
+    <div class="divider">Example</div>
 </div>
 {{< /preview >}}
 


### PR DESCRIPTION
Fixes https://github.com/CreativeBulma/bulma-divider/issues/5